### PR TITLE
chore: bump to rive 0.1.56 and use http url

### DIFF
--- a/getting-started/Assets/Rive/RiveScreen.cs
+++ b/getting-started/Assets/Rive/RiveScreen.cs
@@ -131,7 +131,14 @@ namespace Rive
 
             Camera camera = gameObject.GetComponent<Camera>();
             Assert.IsNotNull(camera, "TestRive must be attached to a camera.");
-            m_renderQueue = new RenderQueue();
+            var startingTexture = new RenderTexture(
+                camera.pixelWidth,
+                camera.pixelHeight,
+                0,
+                RenderTextureFormat.ARGB32
+            );
+            startingTexture.enableRandomWrite = true;
+            m_renderQueue = new RenderQueue(startingTexture);
             m_commandBuffer = m_renderQueue.toCommandBuffer();
             camera.AddCommandBuffer(cameraEvent, m_commandBuffer);
             if (!RenderQueue.supportsDrawingToScreen())

--- a/getting-started/Packages/manifest.json
+++ b/getting-started/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "app.rive.rive-unity": "git@github.com:rive-app/rive-unity.git?path=package#v0.1.38",
+    "app.rive.rive-unity": "https://github.com/rive-app/rive-unity.git?path=package#v0.1.56",
     "com.unity.collab-proxy": "2.2.0",
     "com.unity.feature.development": "1.0.1",
     "com.unity.ide.visualstudio": "2.0.22",

--- a/getting-started/Packages/packages-lock.json
+++ b/getting-started/Packages/packages-lock.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "app.rive.rive-unity": {
-      "version": "git@github.com:rive-app/rive-unity.git?path=package#v0.1.38",
+      "version": "https://github.com/rive-app/rive-unity.git?path=package#v0.1.56",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "1e5735d099c4d3b626f06d529c1b64ce5a981252"
+      "hash": "8209f8e1f76940294ff202f2124467c043a205e7"
     },
     "com.unity.collab-proxy": {
       "version": "2.2.0",

--- a/minion-head-tracking-urp/Assets/Rive/RiveTexture.cs
+++ b/minion-head-tracking-urp/Assets/Rive/RiveTexture.cs
@@ -26,6 +26,7 @@ public class RiveTexture : MonoBehaviour
              0,
              RenderTextureFormat.ARGB32
          );
+        _renderTexture.enableRandomWrite = true;
 
         Renderer renderer = GetComponent<Renderer>();
         Material material = renderer.material;

--- a/minion-head-tracking-urp/Packages/manifest.json
+++ b/minion-head-tracking-urp/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "app.rive.rive-unity": "https://github.com/rive-app/rive-unity.git?path=package#v0.1.39",
+    "app.rive.rive-unity": "https://github.com/rive-app/rive-unity.git?path=package#v0.1.56",
     "com.unity.collab-proxy": "2.2.0",
     "com.unity.ide.rider": "3.0.24",
     "com.unity.ide.visualstudio": "2.0.18",

--- a/minion-head-tracking-urp/Packages/packages-lock.json
+++ b/minion-head-tracking-urp/Packages/packages-lock.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "app.rive.rive-unity": {
-      "version": "https://github.com/rive-app/rive-unity.git?path=package#v0.1.39",
+      "version": "https://github.com/rive-app/rive-unity.git?path=package#v0.1.56",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "bb80980cb3ab548c468d08560c749886876b4be1"
+      "hash": "8209f8e1f76940294ff202f2124467c043a205e7"
     },
     "com.unity.burst": {
       "version": "1.8.8",

--- a/ship-fui-3d/Packages/manifest.json
+++ b/ship-fui-3d/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "app.rive.rive-unity": "git@github.com:rive-app/rive-unity.git?path=package#v0.1.38",
+    "app.rive.rive-unity": "https://github.com/rive-app/rive-unity.git?path=package#v0.1.56",
     "com.unity.collab-proxy": "2.2.0",
     "com.unity.feature.development": "1.0.1",
     "com.unity.postprocessing": "3.2.2",

--- a/ship-fui-3d/Packages/packages-lock.json
+++ b/ship-fui-3d/Packages/packages-lock.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "app.rive.rive-unity": {
-      "version": "git@github.com:rive-app/rive-unity.git?path=package#v0.1.38",
+      "version": "https://github.com/rive-app/rive-unity.git?path=package#v0.1.56",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "1e5735d099c4d3b626f06d529c1b64ce5a981252"
+      "hash": "8209f8e1f76940294ff202f2124467c043a205e7"
     },
     "com.unity.collab-proxy": {
       "version": "2.2.0",

--- a/visor-fui/Assets/Scripts/RiveFui.cs
+++ b/visor-fui/Assets/Scripts/RiveFui.cs
@@ -26,6 +26,7 @@ namespace Rive
 
         private void Start()
         {
+            renderTexture.enableRandomWrite = true;
             m_renderQueue = new RenderQueue(renderTexture);
             if (asset != null)
             {

--- a/visor-fui/Packages/manifest.json
+++ b/visor-fui/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "app.rive.rive-unity": "git@github.com:rive-app/rive-unity.git?path=package#v0.1.38",
+    "app.rive.rive-unity": "https://github.com/rive-app/rive-unity.git?path=package#v0.1.56",
     "com.unity.collab-proxy": "2.2.0",
     "com.unity.feature.development": "1.0.1",
     "com.unity.postprocessing": "3.2.2",

--- a/visor-fui/Packages/packages-lock.json
+++ b/visor-fui/Packages/packages-lock.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "app.rive.rive-unity": {
-      "version": "git@github.com:rive-app/rive-unity.git?path=package#v0.1.38",
+      "version": "https://github.com/rive-app/rive-unity.git?path=package#v0.1.56",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "1e5735d099c4d3b626f06d529c1b64ce5a981252"
+      "hash": "8209f8e1f76940294ff202f2124467c043a205e7"
     },
     "com.unity.collab-proxy": {
       "version": "2.2.0",


### PR DESCRIPTION
- Bumps to the latest Rive-Unity, which now requires a RenderTexture when initializing RenderQueue
- Switches from ssh to http for downloading the Rive-Unity package. Which should fix https://github.com/rive-app/rive-unity/issues/17
